### PR TITLE
add js for calendar and calendar updated

### DIFF
--- a/calendar.class.php
+++ b/calendar.class.php
@@ -13,6 +13,114 @@ private $currentDate = null;
 private $daysInMonth = 0;
 private $naviHref = null;
 
+public function dayView(){
+    $year = null;
+    $month = null;
+    $day = null;
+    if($year==null && isset($_GET['year'])){
+		$year = $_GET['year'];
+	}
+	else if ($year == null){
+		$year = date("Y", time());
+    }
+    
+    if($day==null && isset($_GET['day'])){
+		$year = $_GET['day'];
+	}
+	else if ($day == null){
+		$day = date("d", time());
+	}
+
+	if(null == $month && isset($_GET['month'])){
+		$month = $_GET['month'];
+	}
+	else if(null == $month){
+		$month = date("m", time());
+	}
+
+	$this->currentYear = $year;
+	$this->currentMonth = $month;
+    $this->currentDay = $day;
+	$this->daysInMonth = $this->_daysInMonth($month, $year);
+    echo $day;
+	$content='<div class="box-content">'. '<h4>Day View for ' . $month . '/' . $_GET['day'] . '</h4>'.
+                    '</br>'.
+
+          '<form action="calendar.php" method="get">
+                    Subject:</br>
+                    <input type="text" name="subject"</br></br>
+                    Location:</br>
+                    <input type="text" name="location"><br><br>
+                    Start Time: ' . $month . '/' . $_GET['day'] . '/' . $_GET['year'] . '</option>
+                    <select>';
+                    $time = '0000';
+                        for ($i = 0; $i < 96; $i++){
+                            $content .= '<option value="startClock">'; 
+                            //echo substr($time, 1, 1); echo '</br>';
+                            if (strlen ($time) == 3)
+                                $time = '0' . $time;
+                            else if (strlen ($time) == 2)
+                                $time = '00' . $time;
+                            else if (strlen ($time) == 1)
+                                $time = '000' . $time;
+                            if(substr($time, 2, 4) == 60){
+                                $oneSpot = substr($time, 0, 1);
+                                $twoSpot = substr($time, 1, 1) + 1;
+                                $time = $oneSpot;
+                                $time .= $twoSpot;
+                                $time .= "00";
+                            }
+                            if ($time == '01000')
+                                $time = 1000;
+                            $printTime = substr_replace($time, ':', 2, 0);
+                            $content .= $printTime . '</option>';
+                            if ($time == 1945)
+                                $time = 2000;
+                            else
+                                $time += 15;
+                        }
+                    $content .= '</select></br></br>
+                    End Time: ' . $month . '/' . $_GET['day'] . '/' . $_GET['year'] . '</option>
+                    <select>';
+                        $time = '0000';
+                        for ($i = 0; $i < 96; $i++){
+                            $content .= '<option value="startClock">'; 
+                            //echo substr($time, 1, 1); echo '</br>';
+                            if (strlen ($time) == 3)
+                                $time = '0' . $time;
+                            else if (strlen ($time) == 2)
+                                $time = '00' . $time;
+                            else if (strlen ($time) == 1)
+                                $time = '000' . $time;
+                            if(substr($time, 2, 4) == 60){
+                                $oneSpot = substr($time, 0, 1);
+                                $twoSpot = substr($time, 1, 1) + 1;
+                                $time = $oneSpot;
+                                $time .= $twoSpot;
+                                $time .= "00";
+                            }
+                            if ($time == '01000')
+                                $time = 1000;
+                            $printTime = substr_replace($time, ':', 2, 0);
+                            $content .= $printTime . '</option>';
+                            if ($time == 1945)
+                                $time = 2000;
+                            else
+                                $time += 15;
+                        }
+                    $content .= '</select></br>
+                    </select></br>
+                    <input type="submit" name="cal" value="Submit">
+                 </form></br></br></br></br></br></br></br></br></br></br></br>' .
+             '</div>';
+    return $content;
+}
+
+public function scheduleSelect(){
+
+
+}
+
 public function show(){
 	$year = null;
 	$month = null;

--- a/calendar.php
+++ b/calendar.php
@@ -35,6 +35,14 @@ $calendar = new Calendar();
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+      <!--[if IE]>
+    <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+  <![endif]-->
+  <link rel="stylesheet" type="text/css" href="css/style.css">
+  <link href="http://www.jqueryscript.net/css/jquerysctipttop.css" rel="stylesheet" type="text/css">
+  <link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   </head>
   <body>
     <?php
@@ -46,16 +54,57 @@ $calendar = new Calendar();
 		    	<!--<div id="page-content-wrapper">-->
 			    	<!--<div class="page-content">-->
 			    	
-				    	<div class="container-fluid">
+                    	<div class="container-fluid">
 					    	<div class="row">
 					    	<div id="calendar-widget" class="col-lg-3 col-md-3 col-sm-3">
 					    	<a id="back-to-current" class="btn btn-info" href="<?php echo URL . 'calendar.php?month='.date("m",time()).'&year='.date("Y", time()); ?>" role="button">Back to Current Day</a>
 					    	<?php echo $calendar->show(); ?>
+                            <form method="post">
+                                Enter start and end time for week view: </br>
+                                Start: 
+                                <select name="startView">
+                                    <?php
+                                        $out = '';
+                                        for ($i = 0; $i < 24; $i++){
+                                            if ($i < 10)
+                                                $out .= '<option value="0' . $i . ':00">0' . $i . ':00</option>';
+                                            else
+                                                $out .= '<option value="' . $i . ':00">' . $i . ':00</option>';
+                                        }
+                                        echo $out . '</br>';
+                                    ?>
+                                </select> </br>
+                                End: 
+                                <select name="endView">
+                                    <?php
+                                        $out = '';
+                                        for ($i = 0; $i < 24; $i++){
+                                            if ($i < 10)
+                                                $out .= '<option value="0' . $i . ':00">0' . $i . ':00</option>';
+                                            else
+                                                $out .= '<option value="' . $i . ':00">' . $i . ':00</option>';
+                                        }
+                                        echo $out . '</br>';
+                                    ?>
+                                </select> </br>
+                                <input type="submit" value="Submit">
+                                </form>
+                                <?php //echo $calendar->dayView(); 
+                                //echo $_SERVER["QUERY_STRING"];
+
+                                // use for updating user preferences
+                                if (isset ($_POST['startView']))     //
+                                    $startVar = $_POST['startView']; // 
+                                if (isset ($_POST['endView']))       //
+                                    $endVar = $_POST['endView'];     //
+                                
+                                
+                                ?>
 					    	</div>
+                              <div id="day-schedule"></div>
+
 					    	<div class="col-lg-8 col-md-8 col-sm-8">
-					    		<?php
-					    			echo $calendar->showWeek();
-					    		?>
+					    		<?php //echo $calendar->showWeek(); ?>
 					    	</div>
 					    	</div><!-- row -->
 				    	</div><!-- container-fluid -->
@@ -64,5 +113,43 @@ $calendar = new Calendar();
 		    	<!--</div>page-content-wrapper -->
 	    	<!--</div>sidebar-wrapper -->
     	<!--</div>wrapper -->
+
+            <script src="http://code.jquery.com/jquery-1.11.3.min.js"></script>
+            <script src="index.js"></script>
+
+            <script>
+                var chosenStartTime = "<?php echo $startVar; ?>";
+                var chosenEndTime = "<?php echo $endVar; ?>";
+                (function ($) {
+                    $("#day-schedule").dayScheduleSelector({
+                        
+                        days: [0, 1, 2, 3, 4, 5, 6],
+                        interval: 30,
+                        startTime: chosenStartTime,
+                        endTime: chosenEndTime
+                        
+                    });
+                    $("#day-schedule").on('selected.artsy.dayScheduleSelector', function (e, selected) {
+                    console.log(selected);
+                        })
+                        $("#day-schedule").data('artsy.dayScheduleSelector').deserialize({
+                        '0': [['09:30', '11:00'], ['13:00', '16:30']]
+                    });
+                })($);
+            </script>
+            <script type="text/javascript">
+
+                var _gaq = _gaq || [];
+                _gaq.push(['_setAccount', 'UA-36251023-1']);
+                _gaq.push(['_setDomainName', 'jqueryscript.net']);
+                _gaq.push(['_trackPageview']);
+
+                (function() {
+                    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+                    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+                })();
+
+            </script>
     </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,297 @@
+(function ($) {
+  'use strict';
+
+  var DayScheduleSelector = function (el, options) {
+    this.$el = $(el);
+    this.options = $.extend({}, DayScheduleSelector.DEFAULTS, options);
+    this.render();
+    this.attachEvents();
+    this.$selectingStart = null;
+  }
+
+  DayScheduleSelector.DEFAULTS = {
+    days        : [0, 1, 2, 3, 4, 5, 6],  // Sun - Sat
+    startTime   : '08:00',                // HH:mm format
+    endTime     : '20:00',                // HH:mm format
+    interval    : 30,                     // minutes
+    stringDays  : ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    template    : '<div class="day-schedule-selector">'         +
+                    '<table class="schedule-table">'            +
+                      '<thead class="schedule-header"></thead>' +
+                      '<tbody class="schedule-rows"></tbody>'   +
+                    '</table>'                                  +
+                  '<div>'
+  };
+
+  /**
+   * Render the calendar UI
+   * @public
+   */
+  DayScheduleSelector.prototype.render = function () {
+    this.$el.html(this.options.template);
+    this.renderHeader();
+    this.renderRows();
+  };
+
+  /**
+   * Render the calendar header
+   * @public
+   */
+  DayScheduleSelector.prototype.renderHeader = function () {
+    var stringDays = this.options.stringDays
+      , days = this.options.days
+      , html = '';
+
+    $.each(days, function (i, _) { html += '<th>' + (stringDays[i] || '') + '</th>'; });
+    this.$el.find('.schedule-header').html('<tr><th></th>' + html + '</tr>');
+  };
+
+  /**
+   * Render the calendar rows, including the time slots and labels
+   * @public
+   */
+  DayScheduleSelector.prototype.renderRows = function () {
+    var start = this.options.startTime
+      , end = this.options.endTime
+      , interval = this.options.interval
+      , days = this.options.days
+      , $el = this.$el.find('.schedule-rows');
+
+    $.each(generateDates(start, end, interval), function (i, d) {
+      var daysInARow = $.map(new Array(days.length), function (_, i) {
+        return '<td class="time-slot" data-time="' + hhmm(d) + '" data-day="' + days[i] + '"></td>'
+      }).join();
+
+      $el.append('<tr><td class="time-label">' + hmmAmPm(d) + '</td>' + daysInARow + '</tr>');
+    });
+  };
+
+  /**
+   * Is the day schedule selector in selecting mode?
+   * @public
+   */
+  DayScheduleSelector.prototype.isSelecting = function () {
+    return !!this.$selectingStart;
+  }
+
+  DayScheduleSelector.prototype.select = function ($slot) { $slot.attr('data-selected', 'selected'); }
+  DayScheduleSelector.prototype.deselect = function ($slot) { $slot.removeAttr('data-selected'); }
+
+  function isSlotSelected($slot) { return $slot.is('[data-selected]'); }
+  function isSlotSelecting($slot) { return $slot.is('[data-selecting]'); }
+
+  /**
+   * Get the selected time slots given a starting and a ending slot
+   * @private
+   * @returns {Array} An array of selected time slots
+   */
+  function getSelection(plugin, $a, $b) {
+    var $slots, small, large, temp;
+    if (!$a.hasClass('time-slot') || !$b.hasClass('time-slot') ||
+        ($a.data('day') != $b.data('day'))) { return []; }
+    $slots = plugin.$el.find('.time-slot[data-day="' + $a.data('day') + '"]');
+    small = $slots.index($a); large = $slots.index($b);
+    if (small > large) { temp = small; small = large; large = temp; }
+    return $slots.slice(small, large + 1);
+  }
+
+  DayScheduleSelector.prototype.attachEvents = function () {
+    var plugin = this
+      , options = this.options
+      , $slots;
+
+    this.$el.on('click', '.time-slot', function () {
+      var day = $(this).data('day');
+      if (!plugin.isSelecting()) {  // if we are not in selecting mode
+        if (isSlotSelected($(this))) { plugin.deselect($(this)); }
+        else {  // then start selecting
+          plugin.$selectingStart = $(this);
+          $(this).attr('data-selecting', 'selecting');
+          plugin.$el.find('.time-slot').attr('data-disabled', 'disabled');
+          plugin.$el.find('.time-slot[data-day="' + day + '"]').removeAttr('data-disabled');
+        }
+      } else {  // if we are in selecting mode
+        if (day == plugin.$selectingStart.data('day')) {  // if clicking on the same day column
+          // then end of selection
+          plugin.$el.find('.time-slot[data-day="' + day + '"]').filter('[data-selecting]')
+            .attr('data-selected', 'selected').removeAttr('data-selecting');
+          plugin.$el.find('.time-slot').removeAttr('data-disabled');
+          plugin.$el.trigger('selected.artsy.dayScheduleSelector', [getSelection(plugin, plugin.$selectingStart, $(this))]);
+          plugin.$selectingStart = null;
+        }
+      }
+    });
+
+    this.$el.on('mouseover', '.time-slot', function () {
+      var $slots, day, start, end, temp;
+      if (plugin.isSelecting()) {  // if we are in selecting mode
+        day = plugin.$selectingStart.data('day');
+        $slots = plugin.$el.find('.time-slot[data-day="' + day + '"]');
+        $slots.filter('[data-selecting]').removeAttr('data-selecting');
+        start = $slots.index(plugin.$selectingStart);
+        end = $slots.index(this);
+        if (end < 0) return;  // not hovering on the same column
+        if (start > end) { temp = start; start = end; end = temp; }
+        $slots.slice(start, end + 1).attr('data-selecting', 'selecting');
+      }
+    });
+  };
+
+  /**
+   * Serialize the selections
+   * @public
+   * @returns {Object} An object containing the selections of each day, e.g.
+   *    {
+   *      0: [],
+   *      1: [["15:00", "16:30"]],
+   *      2: [],
+   *      3: [],
+   *      5: [["09:00", "12:30"], ["15:00", "16:30"]],
+   *      6: []
+   *    }
+   */
+  DayScheduleSelector.prototype.serialize = function () {
+    var plugin = this
+      , selections = {};
+
+    $.each(this.options.days, function (_, v) {
+      var start, end;
+      start = end = false; selections[v] = [];
+      plugin.$el.find(".time-slot[data-day='" + v + "']").each(function () {
+        // Start of selection
+        if (isSlotSelected($(this)) && !start) {
+          start = $(this).data('time');
+        }
+
+        // End of selection (I am not selected, so select until my previous one.)
+        if (!isSlotSelected($(this)) && !!start) {
+          end = $(this).data('time');
+        }
+
+        // End of selection (I am the last one :) .)
+        if (isSlotSelected($(this)) && !!start && $(this).is(".time-slot[data-day='" + v + "']:last")) {
+          end = secondsSinceMidnightToHhmm(
+            hhmmToSecondsSinceMidnight($(this).data('time')) + plugin.options.interval * 60);
+        }
+
+        if (!!end) { selections[v].push([start, end]); start = end = false; }
+      });
+    })
+    return selections;
+  };
+
+  /**
+   * Deserialize the schedule and render on the UI
+   * @public
+   * @param {Object} schedule An object containing the schedule of each day, e.g.
+   *    {
+   *      0: [],
+   *      1: [["15:00", "16:30"]],
+   *      2: [],
+   *      3: [],
+   *      5: [["09:00", "12:30"], ["15:00", "16:30"]],
+   *      6: []
+   *    }
+   */
+  DayScheduleSelector.prototype.deserialize = function (schedule) {
+    var plugin = this, i;
+    $.each(schedule, function(d, ds) {
+      var $slots = plugin.$el.find('.time-slot[data-day="' + d + '"]');
+      $.each(ds, function(_, s) {
+        for (i = 0; i < $slots.length; i++) {
+          if ($slots.eq(i).data('time') >= s[1]) { break; }
+          if ($slots.eq(i).data('time') >= s[0]) { plugin.select($slots.eq(i)); }
+        }
+      })
+    });
+  };
+
+  // DayScheduleSelector Plugin Definition
+  // =====================================
+
+  function Plugin(option) {
+    return this.each(function (){
+      var $this   = $(this)
+        , data    = $this.data('artsy.dayScheduleSelector')
+        , options = typeof option == 'object' && option;
+
+      if (!data) {
+        $this.data('artsy.dayScheduleSelector', (data = new DayScheduleSelector(this, options)));
+      }
+    })
+  }
+
+  $.fn.dayScheduleSelector = Plugin;
+
+  /**
+   * Generate Date objects for each time slot in a day
+   * @private
+   * @param {String} start Start time in HH:mm format, e.g. "08:00"
+   * @param {String} end End time in HH:mm format, e.g. "21:00"
+   * @param {Number} interval Interval of each time slot in minutes, e.g. 30 (minutes)
+   * @returns {Array} An array of Date objects representing the start time of the time slots
+   */
+  function generateDates(start, end, interval) {
+    var numOfRows = Math.ceil(timeDiff(start, end) / interval);
+    return $.map(new Array(numOfRows), function (_, i) {
+      // need a dummy date to utilize the Date object
+      return new Date(new Date(2000, 0, 1, start.split(':')[0], start.split(':')[1]).getTime() + i * interval * 60000);
+    });
+  }
+
+  /**
+   * Return time difference in minutes
+   * @private
+   */
+  function timeDiff(start, end) {   // time in HH:mm format
+    // need a dummy date to utilize the Date object
+    return (new Date(2000, 0, 1, end.split(':')[0], end.split(':')[1]).getTime() -
+            new Date(2000, 0, 1, start.split(':')[0], start.split(':')[1]).getTime()) / 60000;
+  }
+
+  /**
+   * Convert a Date object to time in H:mm format with am/pm
+   * @private
+   * @returns {String} Time in H:mm format with am/pm, e.g. '9:30am'
+   */
+  function hmmAmPm(date) {
+    var hours = date.getHours()
+      , minutes = date.getMinutes()
+      , ampm = hours >= 12 ? 'pm' : 'am';
+    return hours + ':' + ('0' + minutes).slice(-2) + ampm;
+  }
+
+  /**
+   * Convert a Date object to time in HH:mm format
+   * @private
+   * @returns {String} Time in HH:mm format, e.g. '09:30'
+   */
+  function hhmm(date) {
+    var hours = date.getHours()
+      , minutes = date.getMinutes();
+    return ('0' + hours).slice(-2) + ':' + ('0' + minutes).slice(-2);
+  }
+
+  function hhmmToSecondsSinceMidnight(hhmm) {
+    var h = hhmm.split(':')[0]
+      , m = hhmm.split(':')[1];
+    return parseInt(h, 10) * 60 * 60 + parseInt(m, 10) * 60;
+  }
+
+  /**
+   * Convert seconds since midnight to HH:mm string, and simply
+   * ignore the seconds.
+   */
+  function secondsSinceMidnightToHhmm(seconds) {
+    var minutes = Math.floor(seconds / 60);
+    return ('0' + Math.floor(minutes / 60)).slice(-2) + ':' +
+           ('0' + (minutes % 60)).slice(-2);
+  }
+
+  // Expose some utility functions
+  window.DayScheduleSelector = {
+    ssmToHhmm: secondsSinceMidnightToHhmm,
+    hhmmToSsm: hhmmToSecondsSinceMidnight
+  };
+
+})(jQuery);


### PR DESCRIPTION
You can merge the two if it won't ruin anything of yours.
- The new week view with drag and drop functionality was added. It works but we need to extrapolate the drag and drops and add them into the database. I don't know what the database looks like right now, so I didn't do that yet.
- You can uncomment line 92 from calendar.php and you get a day view. The problem is that it has some bugs such as the main month calendar cannot be clicked when the form is there? Weird. Also, when you submit the form, it erases the current query string.
- I created a small form that lets the user enter in their "start time" for the day. For example a 9 - 5 job is a better view than one from midnight to midnight. That is in a temporary spot at the moment but needs to make its way somewhere where the user edits their profile. It also needs to go in database so it becomes dynamic and constant (right now, you have to submit the form every time).
